### PR TITLE
Pass non-stringy args as an array

### DIFF
--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -21,7 +21,7 @@ is-deeply(
     "Values on list shouldn't be removed",
 );
 is-deeply(
-    abbrev([1, 2], [1, 3]),
+    abbrev([[1, 2], [1, 3]]),
     ('1 2' => [1, 2], '1 3' => [1, 3]).hash,
     'Non stringy arguments should be stringified.',
 );


### PR DESCRIPTION
It seems that when this code was written, Perl6 wasn't flattening arrays
when passed into subs.  This behaviour changed as part of the Great List
Refactor and now the list of arrays `[1, 2], [1, 3]` was being flattened
to `[1 2 1 3]`.  By wrapping non-stringy arguments in a list, the
desired behaviour is restored and the test suite passes its tests again.

I'm pretty sure this is the desired behaviour expected from the tests, if not, just let me know what you would rather happen here and I can update the PR and resubmit.