### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "Text::Abbrev",
+    "license"     : "BSD-2-Clause",
     "version"     : "0.1.0",
     "description" : "Create an abbreviation table from a list",
     "depends"     : [],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license