### PR TITLE
Fix test breakage

### DIFF
--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -1,5 +1,5 @@
 unit module Abbrev;
-multi sub abbrev (*@words) is export {
+multi sub abbrev (+@words) is export {
     my $seen = SetHash.new;
     my %result;
     for @words {


### PR DESCRIPTION
The `*@` slurpy flattens, so the tests[^1] that expect it not to, fail.

Looking through bot run of all release commits, seems the flattening behaviour
was introed a few months before Perl 6's first stable release.

[1] https://github.com/xfix/perl6-Text-Abbrev/blob/7c00ec9b76a5aacb9b7e63ec56a630e7f67fc48e/t/00-basic.t#L24-L26